### PR TITLE
Added support of Google Place Autocomplete:

### DIFF
--- a/src/Provider/GoogleMapsPlaces/Model/GooglePlaceAutocomplete.php
+++ b/src/Provider/GoogleMapsPlaces/Model/GooglePlaceAutocomplete.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Geocoder\Provider\GoogleMapsPlaces\Model;
+
+use Geocoder\Model\Address;
+
+/**
+ * Class GooglePlaceAutocomplete
+ * @package Geocoder\Provider\GoogleMapsPlaces\Model
+ * @author gdw96 <gael.de_weerdt@mailoo.org>
+ */
+final class GooglePlaceAutocomplete extends Address
+{
+    /**
+     * @var string|null $id
+     */
+    private $id;
+    /**
+     * @var string|null $description
+     */
+    private $description;
+    /**
+     * @var int|null
+     */
+    private $distance_meters;
+    /**
+     * @var array|null $matchedSubstrings
+     */
+    private $matchedSubstrings;
+    /**
+     * @var array|null $terms - Represents parts of `description` field (example : 'Paris, France').
+     * So, this array should look like:
+     * ```
+     * [
+     *     ['offset' => 0, 'value' => 'Paris'],
+     *     ['offset' => 7, 'value' => 'France']
+     * ]
+     * ```
+     */
+    private $terms;
+    /**
+     * @var StructuredFormatting|null
+     */
+    private $structuredFormatting;
+    /**
+     * @var array
+     */
+    private $types;
+
+    /**
+     * @return string|null
+     *
+     * @see https://developers.google.com/places/place-id
+     */
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string|null $id
+     * @return GooglePlaceAutocomplete
+     */
+    public function withId(?string $id = null): GooglePlaceAutocomplete
+    {
+        $new = clone $this;
+        $new->id = $id;
+
+        return $new;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string|null $description
+     * @return GooglePlaceAutocomplete
+     */
+    public function withDescription(?string $description = null): GooglePlaceAutocomplete
+    {
+        $new = clone $this;
+        $new->description = $description;
+
+        return $new;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getDistanceMeters(): ?int
+    {
+        return $this->distance_meters;
+    }
+
+    /**
+     * @param int|null $distance_meters
+     * @return GooglePlaceAutocomplete
+     */
+    public function withDistanceMeters(?int $distance_meters = null): GooglePlaceAutocomplete
+    {
+        $new = clone $this;
+        $new->distance_meters = $distance_meters;
+
+        return $new;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getMatchedSubstrings(): ?array
+    {
+        return $this->matchedSubstrings;
+    }
+
+    /**
+     * @param array|null $matchedSubstrings
+     * @return GooglePlaceAutocomplete
+     */
+    public function withMatchedSubstrings(?array $matchedSubstrings = null): GooglePlaceAutocomplete
+    {
+        $new = clone $this;
+        $new->matchedSubstrings = (count($matchedSubstrings) > 0) ? $matchedSubstrings : null;
+
+        return $new;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getTerms(): ?array
+    {
+        return $this->terms;
+    }
+
+    /**
+     * @param array|null $terms
+     * @return GooglePlaceAutocomplete
+     */
+    public function withTerms(?array $terms = null): GooglePlaceAutocomplete
+    {
+        $new = clone $this;
+        $new->terms = $terms;
+
+        return $new;
+    }
+
+    /**
+     * @return StructuredFormatting|null
+     */
+    public function getStructuredFormatting(): ?StructuredFormatting
+    {
+        return $this->structuredFormatting;
+    }
+
+    /**
+     * @param StructuredFormatting|null $structuredFormatting
+     * @return GooglePlaceAutocomplete
+     */
+    public function withStructuredFormatting(?StructuredFormatting $structuredFormatting = null): GooglePlaceAutocomplete
+    {
+        $new = clone $this;
+        $new->structuredFormatting = $structuredFormatting;
+
+        return $new;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTypes(): array
+    {
+        return $this->types;
+    }
+
+    /**
+     * @param array $types
+     * @return GooglePlaceAutocomplete
+     */
+    public function withTypes(array $types): GooglePlaceAutocomplete
+    {
+        $new = clone $this;
+        $new->types = $types;
+
+        return $new;
+    }
+}

--- a/src/Provider/GoogleMapsPlaces/Model/StructuredFormatting.php
+++ b/src/Provider/GoogleMapsPlaces/Model/StructuredFormatting.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Geocoder package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license    MIT License
+ */
+
+namespace Geocoder\Provider\GoogleMapsPlaces\Model;
+
+/**
+ * Class StructuredFormatting.
+ * @package Geocoder\Provider\GoogleMapsPlaces\Model
+ * @author gdw96 <gael.de_weerdt@mailoo.org>
+ * @see GooglePlaceAutocomplete
+ */
+class StructuredFormatting {
+    /**
+     * @var string|null $mainText
+     */
+    private $mainText;
+    /**
+     * @var string|null $secondaryText
+     */
+    private $secondaryText;
+    /**
+     * @var array|null $mainTextMatchedSubstrings - Represents substrings of `mainText` field that match with input search query.
+     * It should look like:
+     * ```
+     * [
+     *     [ 'length' => 5, 'offset' => 0],
+     * ]
+     * ```
+     */
+    private $mainTextMatchedSubstrings;
+
+    /**
+     * StructuredFormatting constructor.
+     * @param string|null $mainText
+     * @param string|null $secondaryText
+     * @param array|null $mainTextMatchedSubstrings
+     */
+    public function __construct(?string $mainText, ?string $secondaryText = null, ?array $mainTextMatchedSubstrings = null) {
+        $this->mainText = $mainText;
+        $this->secondaryText = $secondaryText;
+        $this->mainTextMatchedSubstrings = $mainTextMatchedSubstrings;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getMainText(): ?string
+    {
+        return $this->mainText;
+    }
+
+    /**
+     * @param string|null $mainText
+     * @return StructuredFormatting
+     */
+    public function setMainText(?string $mainText = null): StructuredFormatting
+    {
+        $this->mainText = $mainText;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSecondaryText(): ?string
+    {
+        return $this->secondaryText;
+    }
+
+    /**
+     * @param string|null $secondaryText
+     * @return StructuredFormatting
+     */
+    public function setSecondaryText(?string $secondaryText = null): StructuredFormatting
+    {
+        $this->secondaryText = $secondaryText;
+        return $this;
+    }
+
+    /**
+     * Return `null` or array like (it represents substrings matches with search query input):
+     * ```
+     * [
+     *     [ 'length' => 5, 'offset' => 0],
+     * ]
+     * ```
+     * @return array|null
+     */
+    public function getMainTextMatchedSubstrings(): ?array
+    {
+        return $this->mainTextMatchedSubstrings;
+    }
+
+    /**
+     * `$mainTextMatchedSubstrings` must have this format (example):
+     * ```
+     * [
+     *     [ 'length' => 5, 'offset' => 0],
+     * ]
+     * ```
+     * @param array|null $mainTextMatchedSubstrings
+     * @return StructuredFormatting
+     */
+    public function setMainTextMatchedSubstrings(?array $mainTextMatchedSubstrings = null): StructuredFormatting
+    {
+        $this->mainTextMatchedSubstrings = $mainTextMatchedSubstrings;
+        return $this;
+    }
+}

--- a/src/Provider/GoogleMapsPlaces/README.md
+++ b/src/Provider/GoogleMapsPlaces/README.md
@@ -54,6 +54,29 @@ $results = $provider->geocodeQuery(
 );
 ```
 
+#### Autocomplete mode
+This mode will perform an autocomplete search based on the input text. Very useful to search for places with a partial or
+limited textual entry. Or to return location proposals while a user is typing.
+
+Anyway, you can do this like this:
+```php
+$results = $provider->geocodeQuery(
+    GeocodeQuery::create('Par')
+        ->withData('mode', GoogleMapsPlaces::GEOCODE_MODE_AUTOCOMPLETE)
+        ->withData('types', '(cities)')
+        ->withData('components', 'country:fr')
+);
+```
+
+This query returns a list of French cities that contain 'Par' in their name (we can imagine that it returns 'Paris' first).
+To know all optional parameters you can set, see [Google Place Autocomplete documentation](https://developers.google.com/maps/documentation/places/web-service/autocomplete).
+
+We recommended to set `sessiontoken` parameters ([see doc](https://developers.google.com/maps/documentation/places/web-service/autocomplete#session_tokens)),
+If you need to retrieve the details of the autocompleted location.  
+
+This request return a list of `GooglePlaceAutocomplete` objects, corresponding to the Google Place API response. See this class
+or [Google Place API documentation](https://developers.google.com/maps/documentation/places/web-service/autocomplete#place_autocomplete_responses) for the returned values.
+
 ### Reverse Geocoding
 Three options available for reverse geocoding of latlon coordinates:
 

--- a/src/Provider/GoogleMapsPlaces/Tests/.cached_responses/maps.googleapis.com_117d70748897e4ab2e90f416cfcf3413f3a45a89
+++ b/src/Provider/GoogleMapsPlaces/Tests/.cached_responses/maps.googleapis.com_117d70748897e4ab2e90f416cfcf3413f3a45a89
@@ -1,0 +1,166 @@
+s:4414:"{
+   "predictions" : [
+      {
+         "description" : "Paris, France",
+         "matched_substrings" : [
+            {
+               "length" : 5,
+               "offset" : 0
+            }
+         ],
+         "place_id" : "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",
+         "reference" : "ChIJD7fiBh9u5kcRYJSMaMOCCwQ",
+         "structured_formatting" : {
+            "main_text" : "Paris",
+            "main_text_matched_substrings" : [
+               {
+                  "length" : 5,
+                  "offset" : 0
+               }
+            ],
+            "secondary_text" : "France"
+         },
+         "terms" : [
+            {
+               "offset" : 0,
+               "value" : "Paris"
+            },
+            {
+               "offset" : 7,
+               "value" : "France"
+            }
+         ],
+         "types" : [ "locality", "political", "geocode" ]
+      },
+      {
+         "description" : "Parisot, France",
+         "matched_substrings" : [
+            {
+               "length" : 5,
+               "offset" : 0
+            }
+         ],
+         "place_id" : "ChIJPbgDXcoqrBIRf74-UUHi4z4",
+         "reference" : "ChIJPbgDXcoqrBIRf74-UUHi4z4",
+         "structured_formatting" : {
+            "main_text" : "Parisot",
+            "main_text_matched_substrings" : [
+               {
+                  "length" : 5,
+                  "offset" : 0
+               }
+            ],
+            "secondary_text" : "France"
+         },
+         "terms" : [
+            {
+               "offset" : 0,
+               "value" : "Parisot"
+            },
+            {
+               "offset" : 9,
+               "value" : "France"
+            }
+         ],
+         "types" : [ "locality", "political", "geocode" ]
+      },
+      {
+         "description" : "Paris-l'Hôpital, France",
+         "matched_substrings" : [
+            {
+               "length" : 5,
+               "offset" : 0
+            }
+         ],
+         "place_id" : "ChIJPb3wuJFZ8kcREOAOszTOCQQ",
+         "reference" : "ChIJPb3wuJFZ8kcREOAOszTOCQQ",
+         "structured_formatting" : {
+            "main_text" : "Paris-l'Hôpital",
+            "main_text_matched_substrings" : [
+               {
+                  "length" : 5,
+                  "offset" : 0
+               }
+            ],
+            "secondary_text" : "France"
+         },
+         "terms" : [
+            {
+               "offset" : 0,
+               "value" : "Paris-l'Hôpital"
+            },
+            {
+               "offset" : 17,
+               "value" : "France"
+            }
+         ],
+         "types" : [ "locality", "political", "geocode" ]
+      },
+      {
+         "description" : "Saint-Denis, France",
+         "matched_substrings" : [
+            {
+               "length" : 11,
+               "offset" : 0
+            }
+         ],
+         "place_id" : "ChIJYW0056pu5kcRDeko-brr78c",
+         "reference" : "ChIJYW0056pu5kcRDeko-brr78c",
+         "structured_formatting" : {
+            "main_text" : "Saint-Denis",
+            "main_text_matched_substrings" : [
+               {
+                  "length" : 11,
+                  "offset" : 0
+               }
+            ],
+            "secondary_text" : "France"
+         },
+         "terms" : [
+            {
+               "offset" : 0,
+               "value" : "Saint-Denis"
+            },
+            {
+               "offset" : 13,
+               "value" : "France"
+            }
+         ],
+         "types" : [ "locality", "political", "geocode" ]
+      },
+      {
+         "description" : "Neuilly-sur-Seine, France",
+         "matched_substrings" : [
+            {
+               "length" : 17,
+               "offset" : 0
+            }
+         ],
+         "place_id" : "ChIJtZbjc2Nl5kcRl7My9Zx1Odw",
+         "reference" : "ChIJtZbjc2Nl5kcRl7My9Zx1Odw",
+         "structured_formatting" : {
+            "main_text" : "Neuilly-sur-Seine",
+            "main_text_matched_substrings" : [
+               {
+                  "length" : 17,
+                  "offset" : 0
+               }
+            ],
+            "secondary_text" : "France"
+         },
+         "terms" : [
+            {
+               "offset" : 0,
+               "value" : "Neuilly-sur-Seine"
+            },
+            {
+               "offset" : 19,
+               "value" : "France"
+            }
+         ],
+         "types" : [ "locality", "political", "geocode" ]
+      }
+   ],
+   "status" : "OK"
+}
+";


### PR DESCRIPTION
 - Add `buildPlaceAutocompleteQuery`, `parseMatchedSubstrings`, `parseStructuredFormatting` and `parseTerms` methods to `GoogleMapsPlaces.php`.
 - Add classes `GooglePlaceAutocomplete` and `StructuredFormatting`(result of autocompleted queries).
 - Edit `fetchURL` method for Google Place Autocomplete (response are different).
 - Edit `README.md` for document the new GeocodeQuery mode.
 - Add `testGeocodePlaceAutocompleteMode` method to `GooglePlaceTest.php`. Test pass with success (and tested in a Symfony application successfully).